### PR TITLE
Add assertions to ChangeStatusCommand for improved error handling

### DIFF
--- a/src/main/java/henry/command/ChangeStatusCommand.java
+++ b/src/main/java/henry/command/ChangeStatusCommand.java
@@ -51,6 +51,7 @@ public class ChangeStatusCommand extends Command {
                         + task.toString()
                         + "\n";
             } else {
+                assert (this.inputList)[0].equals("unmark");
                 //check if task is already unmarked
                 if (!task.isDone()) {
                     throw new HenryException("The task is already unmarked!");


### PR DESCRIPTION
Introduced assertions to ensure that the command is either "mark" or "unmark" before performing any status change on tasks. This ensures that only valid commands are executed, preventing potential errors caused by unexpected or invalid inputs.